### PR TITLE
set apply to last chosen label

### DIFF
--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -30,6 +30,8 @@ const $panel = $("#main-panel");
 const $container = $("#roi-container-wrapper");
 const $container_inner = $("#roi-container");
 
+let lastAppliedLabel = undefined;
+
 $('#filter-before-date').datetimepicker({
     inline: false,
     format: 'm/d/Y H:i',
@@ -210,6 +212,7 @@ function applyLabelSubmit(){
     if(!label_name){
         return false;
     }
+    lastAppliedLabel = label_name;
     let annotations = [];
     for (let i=0; i<selected_rois.length; i++){
         let roi = $(selected_rois[i]).data("roi-id");
@@ -291,7 +294,7 @@ function buildLabelSelect(){
     if(recent_labels){
         for (let i=0; i<recent_labels.length; i++){
             let label_name = recent_labels[i];
-            let selected = i==0?'selected':'';
+            let selected = label_name==lastAppliedLabel?'selected':'';
             $apply_label_select.append($(`<option ${selected} value="${label_name}" > ${label_name} </option>`));
         }
     }
@@ -302,7 +305,7 @@ function buildLabelSelect(){
         let selected = filterBy==label_name?'selected':'';
         let has_winning_class = LABEL_LIST[i].has_winning?'class="has_winning"':'';
         $filter_label.append($(`<option ${selected} value="${label_name}" ${has_winning_class} > ${label_name} </option>`));
-        if(recent_labels){//if you have a recent label at all, it has been selected above, so prevent selection here.
+        if(lastAppliedLabel){//if you have a last applied label, it has been selected above, so prevent selection here.
             selected = "";
         }
         $apply_label_select.append($(`<option ${selected} value="${label_name}" ${has_winning_class} > ${label_name} </option>`));

--- a/assets/src/js/app.js
+++ b/assets/src/js/app.js
@@ -302,6 +302,9 @@ function buildLabelSelect(){
         let selected = filterBy==label_name?'selected':'';
         let has_winning_class = LABEL_LIST[i].has_winning?'class="has_winning"':'';
         $filter_label.append($(`<option ${selected} value="${label_name}" ${has_winning_class} > ${label_name} </option>`));
+        if(recent_labels){//if you have a recent label at all, it has been selected above, so prevent selection here.
+            selected = "";
+        }
         $apply_label_select.append($(`<option ${selected} value="${label_name}" ${has_winning_class} > ${label_name} </option>`));
     }
 }


### PR DESCRIPTION
@joefutrelle , at first I was going to build out this functionality, but then I noticed we're already keeping track of the last 5 recent labels. It was a very quick change to set the \<select\> to whatever `recent_labels[0]` is. The trouble is, because it's using local storage, it's persisting on refresh, and would take extra inelegant logic to make it match the filter_label select on refresh.

So, The only way a user would see the "[The new behavior where the default assign label matches the view label at first is good--it should only do that when we first load the class page though.]" is if they have never applied a label, and their `recent_labels` store is empty.

It feels like this would be simpler and slicker - let me know what you think and I can make it work either way.

