### PR TITLE
parameterize postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgres:12-alpine
+    image: postgres:${POSTGRES_TAG:-12-alpine}
     environment:
       - POSTGRES_DB=photic
       - POSTGRES_USER=photic

--- a/env.example
+++ b/env.example
@@ -13,6 +13,9 @@ HTTPS_PROXY="http://proxy.example.com:1234"
 # Path to image files
 ROI_PATH=/mnt/data_files
 
+# Version tag for PostgreSQL image
+POSTGRES_TAG=14-alpine
+
 # Location to store PostgreSQL database files
 POSTGRES_DATA_PATH=/srv/postgresql/data
 


### PR DESCRIPTION
This allows a postgres image tag to be set in `.env` which defaults to `12-alpine`